### PR TITLE
add data bridge extension to base ide

### DIFF
--- a/images/base-ide/package.json.patch
+++ b/images/base-ide/package.json.patch
@@ -1,6 +1,7 @@
 {
   "theiaPlugins": {
-    "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix"
+    "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
+    "data-bridge": "https://github.com/ls1intum/theia-data-bridge/releases/download/v0.0.12/data-bridge-0.0.12.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",


### PR DESCRIPTION
Adds the data bridge extension to all language-specific images through the base-ide image. Won't have any effect beside the user being able to find it in the installed extensions section. It will be used as soon as the respective prewarming changes in the operator are completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data-bridge plugin v0.0.12 to the IDE environment, enabling new data bridge functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->