### PR TITLE
Disable Red Hat telemetry by default

### DIFF
--- a/images/java-17/project/.theia/settings.json
+++ b/images/java-17/project/.theia/settings.json
@@ -9,5 +9,6 @@
     "java.help.firstView": "none",
     "java.help.showReleaseNotes": false,
     "java.silentNotification": true,
+    "redhat.telemetry.enabled": false,
     "telemetry.telemetryLevel": false
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Disables the Red Hat telemetry notification popup in the Java blueprint by adding `"redhat.telemetry.enabled": false` to the settings.json file. This prevents users from seeing the "Help Red Hat improve its extensions by allowing them to collect usage data" notification when starting the Java IDE.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Build and start the Java-17 blueprint
2. Verify that the Red Hat telemetry notification does not appear
3. Confirm that the Java Language Server and other Java extensions work normally

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled telemetry in the development environment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->