### PR TITLE
fix(rust): update rust-analyzer extension and server for compatibility

### DIFF
--- a/images/rust/ToolDockerfile
+++ b/images/rust/ToolDockerfile
@@ -91,12 +91,15 @@ ENV USE_LOCAL_GIT=true
 USER theia
 
 # Install Rust with minimal profile and cleanup
+# Replace bundled rust-analyzer server with rustup version to ensure
+# proc-macro API version compatibility with the Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rust.sh \
     && chmod +x rust.sh \
     && ./rust.sh -y --profile minimal \
     && rm rust.sh \
     && . "$HOME/.cargo/env" \
     && rustup component add rust-analyzer \
+    && cp /home/theia/.cargo/bin/rust-analyzer /home/theia/plugins/rust-analyzer/extension/server/rust-analyzer \
     && rm -rf $HOME/.cargo/registry \
     && rm -rf $HOME/.cargo/git \
     && rm -rf $HOME/.rustup/downloads \

--- a/images/rust/package.json.patch
+++ b/images/rust/package.json.patch
@@ -1,7 +1,7 @@
 {
   "theiaPlugins": {
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
-    "rust-analyzer": "https://open-vsx.org/api/rust-lang/rust-analyzer/linux-x64/0.4.2114/file/rust-lang.rust-analyzer-0.4.2114@linux-x64.vsix"
+    "rust-analyzer": "https://open-vsx.org/api/rust-lang/rust-analyzer/linux-x64/0.4.2768/file/rust-lang.rust-analyzer-0.4.2768@linux-x64.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",


### PR DESCRIPTION
## Summary
This PR fixes the `rust-analyzer` errors in the Rust Theia image.

### Problem
Two separate issues were causing errors:

1. **cargo.cfgs serialization bug** - Extension version `0.4.2114` had a bug that sent `cargo.cfgs` as a map (`{debug_assertions: null}`) instead of an array (`["debug_assertions"]`), causing:
   ```
   WARN Failed to deserialize config field at /cargo/cfgs: Error("invalid type: map, expected a sequence")
   ```

2. **proc-macro API version mismatch** - The bundled standalone rust-analyzer server (`0.3.x`) had an older proc-macro API version than the Rust toolchain (`1.93.0`), causing:
   ```
   ERROR proc-macro server's api version (6) is newer than rust-analyzer's (4)
   ```

### Solution
- **Update rust-analyzer extension** from `0.4.2114` to `0.4.2768` (fixes the cfgs serialization bug)
- **Replace bundled server** with the rustup-installed version (ensures proc-macro API compatibility)

### Changes
| File | Change |
|------|--------|
| `package.json.patch` | Update extension URL to version `0.4.2768` |
| `ToolDockerfile` | Add `cp` command to replace bundled server with rustup version |

### Verification
- ✅ Built and tested on ARM64 (Apple Silicon)
- ✅ No `cargo.cfgs` deserialization errors
- ✅ No proc-macro API version errors
- ✅ rust-analyzer initializes and works correctly