### PR TITLE
remove addFirst

### DIFF
--- a/images/java-17/gradle/remote-cache.gradle
+++ b/images/java-17/gradle/remote-cache.gradle
@@ -37,11 +37,11 @@ def dependencyCacheUrl = System.getenv('DEPENDENCY_CACHE_URL')
 if (dependencyCacheEnabled && dependencyCacheUrl?.trim()) {
     allprojects {
         repositories {
-            addFirst(maven {
+            maven {
                 name = 'Dependency Cache'
                 url = dependencyCacheUrl
                 allowInsecureProtocol = true
-            })
+            }
         }
     }
 


### PR DESCRIPTION
Since maven already adds the Dependency Cache, and addFirst readds it, this results in a Error "Dependency Cache already added to Project"

This PR removes addFirst. Since allProjects gets already executed before the build.gradle, its still the first Dependency and will used if possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Gradle dependency cache repository resolution order to use default repository ordering instead of explicit first-position insertion. This may affect the order in which repositories are queried during dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->