### PR TITLE
bug/remove-telemetry-prompt-from-java-templates

### DIFF
--- a/images/java-17-templates/ToolDockerfile
+++ b/images/java-17-templates/ToolDockerfile
@@ -87,9 +87,6 @@ COPY --chown=theia:theia images/java-17/gradle/remote-cache.gradle /home/theia/.
 # Copy additional plugins
 COPY --from=plugin-image --chown=theia:theia /home/theia/plugins /home/theia/plugins
 
-# Copy the project configuration files
-COPY --chown=theia:theia images/java-17/project /home/project
-
 # Copy entrypoint script for template loading
 COPY --chown=theia:theia images/java-17-templates/entrypoint.sh /home/theia/entrypoint.sh
 # Copy project templates for standalone mode

--- a/images/java-17-templates/templates/gradle/.vscode/settings.json
+++ b/images/java-17-templates/templates/gradle/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "extensions.ignoreRecommendations": true,
+    "files.exclude": {
+        "**/.theia": true,
+        "persisted": true,
+        "lost+found": true
+    },
+    "java.help.collectErrorLog": false,
+    "java.help.firstView": "none",
+    "java.help.showReleaseNotes": false,
+    "java.silentNotification": true,
+    "redhat.telemetry.enabled": false,
+    "telemetry.telemetryLevel": "off"
+}

--- a/images/java-17-templates/templates/maven/.vscode/settings.json
+++ b/images/java-17-templates/templates/maven/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "extensions.ignoreRecommendations": true,
+    "files.exclude": {
+        "**/.theia": true,
+        "persisted": true,
+        "lost+found": true
+    },
+    "java.help.collectErrorLog": false,
+    "java.help.firstView": "none",
+    "java.help.showReleaseNotes": false,
+    "java.silentNotification": true,
+    "redhat.telemetry.enabled": false,
+    "telemetry.telemetryLevel": "off"
+}


### PR DESCRIPTION
This pr disables the telemetry prompt for the java templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration files to Java 17 project templates for Gradle and Maven, optimizing IDE behavior by reducing telemetry, suppressing notifications, and configuring extension settings for a cleaner development workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->