### PR TITLE
add lldb

### DIFF
--- a/images/c/package.json.patch
+++ b/images/c/package.json.patch
@@ -2,7 +2,8 @@
   "theiaPlugins": {
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
     "MakefileTools": "https://open-vsx.org/api/ms-vscode/makefile-tools/0.9.10/file/ms-vscode.makefile-tools-0.9.10.vsix",
-    "clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.29/file/llvm-vs-code-extensions.vscode-clangd-0.1.29.vsix"
+    "clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.29/file/llvm-vs-code-extensions.vscode-clangd-0.1.29.vsix",
+    "vadimcn.vscode-lldb": "https://github.com/vadimcn/codelldb/releases/download/v1.12.2/codelldb-linux-x64.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",

--- a/images/rust/package.json.patch
+++ b/images/rust/package.json.patch
@@ -1,7 +1,8 @@
 {
   "theiaPlugins": {
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
-    "rust-analyzer": "https://open-vsx.org/api/rust-lang/rust-analyzer/linux-x64/0.4.2768/file/rust-lang.rust-analyzer-0.4.2768@linux-x64.vsix"
+    "rust-analyzer": "https://open-vsx.org/api/rust-lang/rust-analyzer/linux-x64/0.4.2768/file/rust-lang.rust-analyzer-0.4.2768@linux-x64.vsix",
+    "vadimcn.vscode-lldb": "https://github.com/vadimcn/codelldb/releases/download/v1.12.2/codelldb-linux-x64.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",


### PR DESCRIPTION
This PR adds the lldb debugger to C and Rust images.
-> this enables a way to debug on this images.

To Test:
Deployed on Test2, or use images with pr tag pr-146
Set a debug breakpoint
Running the debugger should work without any issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated C/C++ development environment configuration to include additional debugging and language analysis tools.
  * Updated Rust development environment configuration with a newer version of the language analysis tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->