### PR TITLE
feat: set custom color theme correctly in all images

### DIFF
--- a/images/base-ide/project/.vscode/settings.json
+++ b/images/base-ide/project/.vscode/settings.json
@@ -6,6 +6,5 @@
         "lost+found": true
     },
     "telemetry.telemetryLevel": "off",
-    "workbench.preferredDarkColorTheme": "edu-ide-theme-dark",
-    "workbench.preferredLightColorTheme": "edu-ide-theme-light"
+    "workbench.colorTheme": "edu-ide-theme-dark",
 }

--- a/images/c/project/.vscode/settings.json
+++ b/images/c/project/.vscode/settings.json
@@ -5,5 +5,6 @@
         "persisted": true,
         "lost+found": true
     },
-    "telemetry.telemetryLevel": "off"
+    "workbench.colorTheme": "edu-ide-theme-dark",
+    "telemetry.telemetryLevel": "off",
 }

--- a/images/java-17-templates/templates/gradle/.vscode/settings.json
+++ b/images/java-17-templates/templates/gradle/.vscode/settings.json
@@ -10,5 +10,6 @@
     "java.help.showReleaseNotes": false,
     "java.silentNotification": true,
     "redhat.telemetry.enabled": false,
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/java-17-templates/templates/maven/.vscode/settings.json
+++ b/images/java-17-templates/templates/maven/.vscode/settings.json
@@ -10,5 +10,6 @@
     "java.help.showReleaseNotes": false,
     "java.silentNotification": true,
     "redhat.telemetry.enabled": false,
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/java-17/project/.vscode/settings.json
+++ b/images/java-17/project/.vscode/settings.json
@@ -10,5 +10,6 @@
     "java.help.showReleaseNotes": false,
     "java.silentNotification": true,
     "redhat.telemetry.enabled": false,
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/javascript/project/.vscode/settings.json
+++ b/images/javascript/project/.vscode/settings.json
@@ -5,6 +5,7 @@
         "persisted": true,
         "lost+found": true
     },
+    "workbench.colorTheme": "edu-ide-theme-dark",
     /**
      * JavaScript Essentials Config
      */

--- a/images/ocaml/project/.vscode/settings.json
+++ b/images/ocaml/project/.vscode/settings.json
@@ -5,5 +5,6 @@
         "persisted": true,
         "lost+found": true
     },
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/python/project/.vscode/settings.json
+++ b/images/python/project/.vscode/settings.json
@@ -5,5 +5,6 @@
         "persisted": true,
         "lost+found": true
     },
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/rust/project/.vscode/settings.json
+++ b/images/rust/project/.vscode/settings.json
@@ -5,5 +5,6 @@
         "persisted": true,
         "lost+found": true
     },
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }

--- a/images/theia-no-ls/.theia/settings.json
+++ b/images/theia-no-ls/.theia/settings.json
@@ -5,5 +5,6 @@
         "persisted": true,
         "lost+found": true
     },
+    "workbench.colorTheme": "edu-ide-theme-dark",
     "telemetry.telemetryLevel": "off"
 }


### PR DESCRIPTION
# Features
Sets EduIDE dark color theme as preference in each setting.json of each image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace settings across all project templates to consistently use the `edu-ide-theme-dark` color theme by default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EduIDE/EduIDE/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->