### PR TITLE
fix: use TaskService.run instead of runTaskByLabel

### DIFF
--- a/docs/split-button-toolbar-guide.md
+++ b/docs/split-button-toolbar-guide.md
@@ -200,7 +200,7 @@ Common icons for toolbar buttons (see [Codicon reference](https://microsoft.gith
 - **Icon:** `play`
 - **Priority:** `0` (leftmost)
 - **Config source:** `tasks.json` via `TaskConfigurations.getTasks()`
-- **Execution:** `TaskService.runTaskByLabel()`
+- **Execution:** `TaskService.run()`
 - **Last-run tracking:** `TaskService.getLastTask()`
 - **Listeners:** `TaskConfigurationManager.onDidChangeTaskConfig`, `TaskWatcher.onTaskCreated`
 

--- a/theia-extensions/product/src/browser/toolbar/task-toolbar-contribution.tsx
+++ b/theia-extensions/product/src/browser/toolbar/task-toolbar-contribution.tsx
@@ -3,7 +3,7 @@ import { nls, MenuPath } from '@theia/core';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TaskConfigurations } from '@theia/task/lib/browser/task-configurations';
 import { TaskConfigurationManager } from '@theia/task/lib/browser/task-configuration-manager';
-import { TaskConfiguration, TaskWatcher } from '@theia/task/lib/common';
+import { ContributedTaskConfiguration, TaskConfiguration, TaskWatcher } from '@theia/task/lib/common';
 import { AbstractSplitButtonContribution } from './abstract-split-button-contribution';
 
 export const TASK_RUN_TOOLBAR_MENU: MenuPath = ['task-toolbar', 'run'];
@@ -53,7 +53,8 @@ export class TaskToolbarContribution extends AbstractSplitButtonContribution<Tas
 
     protected async executeConfiguration(config: TaskConfiguration): Promise<void> {
         const token = this.taskService.startUserAction();
-        await this.taskService.runTaskByLabel(token, config.label);
+        const source = (config as ContributedTaskConfiguration)._source;
+        await this.taskService.run(token, source, config.label, config._scope);
     }
 
     protected getConfigurationLabel(config: TaskConfiguration): string {


### PR DESCRIPTION
- runTaskByLabel did not resolve task dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task toolbar contribution documentation.

* **Improvements**
  * Refined task execution implementation with enhanced configuration and source tracking in the toolbar.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EduIDE/EduIDE/pull/149)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->