### PR TITLE
feat: bundle stripped scorpio 2.0.0 and bump artemis extension to 0.4.6 for testing

### DIFF
--- a/images/base-ide/package.json.patch
+++ b/images/base-ide/package.json.patch
@@ -4,7 +4,8 @@
     "vscjava.vscode-java-dependency": null,
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
     "data-bridge": "https://github.com/eduide/eduide-data-bridge/releases/download/v0.0.14/data-bridge-0.0.14.vsix",
-    "scorpio": "https://open-vsx.org/api/tum-aet/artemis-scorpio/1.2.0/file/tum-aet.artemis-scorpio-1.2.0.vsix"
+    "scorpio": "https://open-vsx.org/api/tum-aet/artemis-scorpio/1.2.0/file/tum-aet.artemis-scorpio-1.2.0.vsix",
+    "artemis-extension": "https://open-vsx.org/api/aet-tum/iris-thaumantias/0.4.3/file/aet-tum.iris-thaumantias-0.4.3.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",

--- a/images/base-ide/package.json.patch
+++ b/images/base-ide/package.json.patch
@@ -4,8 +4,8 @@
     "vscjava.vscode-java-dependency": null,
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
     "data-bridge": "https://github.com/eduide/eduide-data-bridge/releases/download/v0.0.14/data-bridge-0.0.14.vsix",
-    "scorpio": "https://open-vsx.org/api/aet-tum/artemis-scorpio/0.0.0/file/aet-tum.artemis-scorpio-0.0.0.vsix",
-    "artemis-extension": "https://open-vsx.org/api/aet-tum/iris-thaumantias/0.4.4/file/aet-tum.iris-thaumantias-0.4.4.vsix"
+    "scorpio": "https://open-vsx.org/api/aet-tum/artemis-scorpio/2.0.0/file/aet-tum.artemis-scorpio-2.0.0.vsix",
+    "artemis-extension": "https://open-vsx.org/api/aet-tum/iris-thaumantias/0.4.6/file/aet-tum.iris-thaumantias-0.4.6.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",

--- a/images/base-ide/package.json.patch
+++ b/images/base-ide/package.json.patch
@@ -4,8 +4,8 @@
     "vscjava.vscode-java-dependency": null,
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
     "data-bridge": "https://github.com/eduide/eduide-data-bridge/releases/download/v0.0.14/data-bridge-0.0.14.vsix",
-    "scorpio": "https://open-vsx.org/api/tum-aet/artemis-scorpio/1.2.0/file/tum-aet.artemis-scorpio-1.2.0.vsix",
-    "artemis-extension": "https://open-vsx.org/api/aet-tum/iris-thaumantias/0.4.3/file/aet-tum.iris-thaumantias-0.4.3.vsix"
+    "scorpio": "https://open-vsx.org/api/aet-tum/artemis-scorpio/0.0.0/file/aet-tum.artemis-scorpio-0.0.0.vsix",
+    "artemis-extension": "https://open-vsx.org/api/aet-tum/iris-thaumantias/0.4.4/file/aet-tum.iris-thaumantias-0.4.4.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",


### PR DESCRIPTION
Swaps the bundled Artemis extensions to their newly published, parallel-installable versions:

- **`aet-tum.iris-thaumantias`**: `0.4.3` → `0.4.6` — patch bump.
- **`scorpio`**: `tum-aet.artemis-scorpio 1.2.0` → `aet-tum.artemis-scorpio 2.0.0` — replaces the full pre-strip build with the freshly stripped Theia-only build. Auto-clone, git identity, env-var reading and server-URL handling stay in scorpio; everything Artemis-specific (auth, Iris chat, exercise sync) is now exclusively in `iris-thaumantias`.

`0.4.6` also retains the data-bridge `getEnv` fix from `0.4.3` (calling the bridge with the required `string[]` argument so Theia detection succeeds when credentials are injected).

Supersedes #138.

## Open-VSX links

- https://open-vsx.org/extension/aet-tum/iris-thaumantias/0.4.6
- https://open-vsx.org/extension/aet-tum/artemis-scorpio/2.0.0

## Summary

- Updates `images/base-ide/package.json.patch` `theiaPlugins`:
  - `scorpio` → `aet-tum/artemis-scorpio/2.0.0`
  - `artemis-extension` → `aet-tum/iris-thaumantias/0.4.6`

## Test plan

- [ ] CI builds all language images successfully
- [ ] After deployment, opening a session via Artemis "Open in Online IDE" results in `Theia detected ✅` in the iris-thaumantias diagnostic
- [ ] Scorpio auto-clone runs without colliding with iris-thaumantias (no duplicate clone, no git identity conflicts)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IDE extension packages to newer versions, including improved versions of Scorpio and Artemis extensions for better compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->