### PR TITLE
ci: build on GitHub runners, dual-arch, via EduIDE/.github@v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,26 +19,13 @@ on:
 
   workflow_dispatch:
     inputs:
-      execution_mode:
-        description: "Build backend to use"
-        required: false
-        default: self-hosted-buildkit
-        type: choice
-        options:
-          - self-hosted-buildkit
-          - github-runners
       image_tag:
-        description: "Optional image tag override (e.g. my-test-tag)"
+        description: "Optional image tag override (e.g. my-test-tag, or 2.3.0 for the release train)"
         required: false
         default: ""
         type: string
-      arc_registry_cache:
-        description: "Enable ARC registry cache import/export (slower on stateful BuildKit; default off)"
-        required: false
-        default: false
-        type: boolean
       disable_layer_cache:
-        description: "Disable Docker layer cache (--no-cache) for stress testing while keeping BuildKit mount caches"
+        description: "Disable the Docker layer cache (--no-cache) for stress testing"
         required: false
         default: false
         type: boolean
@@ -48,91 +35,67 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build-and-push-base:
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/split-build-workflow-modes
+  # The base IDE image every language image is built FROM. Its immutable
+  # sha_tag is passed down so the language images cannot pick up a different
+  # base than the one just built.
+  base:
+    uses: EduIDE/.github/.github/workflows/build-and-push-docker-image.yml@v1
     with:
       docker-file: images/base-ide/BaseDockerfile
       image-name: eduide/eduide/base
       docker-context: .
-      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.image_tag || '' }}
-      execution-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
-      arc-registry-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.arc_registry_cache || false }}
-      cache-from: type=registry,ref=ghcr.io/eduide/eduide:${{ github.event_name == 'pull_request' && format('build-cache-pr-{0}', github.event.pull_request.number) || 'build-cache' }}
-      cache-to: type=registry,ref=ghcr.io/eduide/eduide:${{ github.event_name == 'pull_request' && format('build-cache-pr-{0}', github.event.pull_request.number) || 'build-cache' }},mode=max,image-manifest=true,oci-mediatypes=true
+      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
-      network: host
-      build-amd64: true
-      build-arm64: ${{ github.event_name != 'pull_request' }}
     secrets: inherit
 
-  build-and-push:
-    needs:
-      - build-and-push-base
+  images:
+    needs: base
+    name: ${{ matrix.image-name }}
     strategy:
+      # These are large, independent images. One language failing to build must
+      # not cancel the other thirteen.
       fail-fast: false
       matrix:
         include:
-          - docker-file: images/c/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/c
-          - docker-file: images/c-templates/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/c-templates
-          - docker-file: images/haskell/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/haskell
-          - docker-file: images/java-17/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/java-17
-          - docker-file: images/java-17-templates/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/java-17-templates
-          - docker-file: images/javascript/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/javascript
-          - docker-file: images/ocaml/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/ocaml
-          - docker-file: images/python/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/python
-          - docker-file: images/rust/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/rust
-          - docker-file: images/languageserver/java/Dockerfile
-            docker-context: "."
-            image-name: eduide/eduide/langserver-java
-          - docker-file: images/languageserver/rust/Dockerfile
-            docker-context: "."
-            image-name: eduide/eduide/langserver-rust
-          - docker-file: images/theia-no-ls/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/theia-no-ls
-          - docker-file: images/java-17-no-ls/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/java-17-no-ls
-          - docker-file: images/rust-no-ls/ToolDockerfile
-            docker-context: "."
-            image-name: eduide/eduide/rust-no-ls
-
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/split-build-workflow-modes
+          - image-name: eduide/eduide/c
+            docker-file: images/c/ToolDockerfile
+          - image-name: eduide/eduide/c-templates
+            docker-file: images/c-templates/ToolDockerfile
+          - image-name: eduide/eduide/haskell
+            docker-file: images/haskell/ToolDockerfile
+          - image-name: eduide/eduide/java-17
+            docker-file: images/java-17/ToolDockerfile
+          - image-name: eduide/eduide/java-17-templates
+            docker-file: images/java-17-templates/ToolDockerfile
+          - image-name: eduide/eduide/javascript
+            docker-file: images/javascript/ToolDockerfile
+          - image-name: eduide/eduide/ocaml
+            docker-file: images/ocaml/ToolDockerfile
+          - image-name: eduide/eduide/python
+            docker-file: images/python/ToolDockerfile
+          - image-name: eduide/eduide/rust
+            docker-file: images/rust/ToolDockerfile
+          - image-name: eduide/eduide/langserver-java
+            docker-file: images/languageserver/java/Dockerfile
+          - image-name: eduide/eduide/langserver-rust
+            docker-file: images/languageserver/rust/Dockerfile
+          - image-name: eduide/eduide/theia-no-ls
+            docker-file: images/theia-no-ls/ToolDockerfile
+          - image-name: eduide/eduide/java-17-no-ls
+            docker-file: images/java-17-no-ls/ToolDockerfile
+          - image-name: eduide/eduide/rust-no-ls
+            docker-file: images/rust-no-ls/ToolDockerfile
+    uses: EduIDE/.github/.github/workflows/build-and-push-docker-image.yml@v1
     with:
       docker-file: ${{ matrix.docker-file }}
       image-name: ${{ matrix.image-name }}
-      docker-context: ${{ matrix.docker-context }}
+      docker-context: .
       build-args: |
-        BASE_IDE_TAG=${{ needs.build-and-push-base.outputs.sha_tag }}
-      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.image_tag || '' }}
-      execution-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
-      arc-registry-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.arc_registry_cache || false }}
-      cache-from: type=registry,ref=ghcr.io/eduide/eduide:${{ github.event_name == 'pull_request' && format('build-cache-pr-{0}', github.event.pull_request.number) || 'build-cache' }}
-      cache-to: type=registry,ref=ghcr.io/eduide/eduide:${{ github.event_name == 'pull_request' && format('build-cache-pr-{0}', github.event.pull_request.number) || 'build-cache' }},mode=max,image-manifest=true,oci-mediatypes=true
+        BASE_IDE_TAG=${{ needs.base.outputs.sha_tag }}
+      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
-      network: host
-      build-amd64: true
-      build-arm64: ${{ github.event_name != 'pull_request' }}
     secrets: inherit


### PR DESCRIPTION
Repoints both build jobs at the org-owned reusable workflow added in [EduIDE/.github#1](https://github.com/EduIDE/.github/pull/1).

**This is the only change to this repository in the current deployment rework.** Everything else about EduIDE is deliberately out of scope and belongs to the follow-up program.

## Why

- **Drops the cross-org dependency.** All 15 image builds here point at `ls1intum/.github@feature/split-build-workflow-modes` — an unmerged PR branch in another organisation. If it is deleted, every image build breaks at once.
- **All 15 images become dual-arch on every event, including PRs.** `build-arm64` was disabled for pull requests, so a PR image could not be scheduled onto an arm64 node.
- **`fail-fast: false`**, so one language failing no longer cancels the other thirteen.
- Removes `execution_mode`, `arc_registry_cache`, ARC runner selection and `network: host`. The in-cluster caches those reached (apt-cacher-ng, Verdaccio, Squid, the registry mirrors) are not reachable from GitHub-hosted runners.

## This PR is the real test of the runner migration

The Java images in [EduIDE-Cloud#125](https://github.com/EduIDE/EduIDE-Cloud/pull/125) already passed — ~2.5 min per architecture, all manifests dual-arch. **These are the large ones**, so what to watch here:

1. **Disk.** `free-disk-space` defaults to `true`, reclaiming ~30GB of unused preinstalled toolchains before the build. If a language image still hits `ENOSPC`, the fix is a larger GitHub-hosted runner for that matrix entry — not reinstating ARC.
2. **Duration** versus the previous ARC runs, especially for `base`, which gates the other fourteen.
3. **All 15 manifests report both `linux/amd64` and `linux/arm64`** — the workflow asserts this and fails if not.

The first run will be **cold**: layer cache moves from one shared bucket (`ghcr.io/eduide/eduide`) to one per image, so the 15 images stop evicting each other's layers. Judge steady-state timing on the second run.

## Note on `@v1`

`v1` currently points at the head of EduIDE/.github#1 so this can be validated before that merges. I will re-point it at the merge commit once that PR lands.

## Deliberately not done here

The build matrix is still hand-maintained. Generating it from an `images/images.yaml` manifest — along with the orphaned `swift` image (present in `images/swift/` and `docker-compose.images.yml`, advertised in the README, in no build matrix, therefore never published) — belongs to the EduIDE program, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qeiQRFu8xAMRYWPdZewjG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the image build process to use the shared build workflow.
  - Streamlined base and language image builds with improved job sequencing.
  - Removed manual workflow options for execution mode and registry caching.
  - Preserved image tagging and layer-cache controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->