### PR TITLE
ci: stop building the language-server images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,16 +79,6 @@ jobs:
             docker-file: images/python/ToolDockerfile
           - image-name: eduide/eduide/rust
             docker-file: images/rust/ToolDockerfile
-          - image-name: eduide/eduide/langserver-java
-            docker-file: images/languageserver/java/Dockerfile
-          - image-name: eduide/eduide/langserver-rust
-            docker-file: images/languageserver/rust/Dockerfile
-          - image-name: eduide/eduide/theia-no-ls
-            docker-file: images/theia-no-ls/ToolDockerfile
-          - image-name: eduide/eduide/java-17-no-ls
-            docker-file: images/java-17-no-ls/ToolDockerfile
-          - image-name: eduide/eduide/rust-no-ls
-            docker-file: images/rust-no-ls/ToolDockerfile
     uses: EduIDE/.github/.github/workflows/build-and-push-docker-image.yml@v1
     with:
       docker-file: ${{ matrix.docker-file }}


### PR DESCRIPTION
Retires the external language-server path. Five images are no longer built:

| Image | What it was for |
|---|---|
| `langserver-java`, `langserver-rust` | the sidecar language servers |
| `theia-no-ls`, `java-17-no-ls`, `rust-no-ls` | IDE images with the language server stripped, only useful paired with an external one |

Build matrix drops from **14 to 9** language images.

## The generic sidecar mechanism is NOT removed

Only the language-server-specific images and flavours go. The v1beta11 `sidecars` field on `AppDefinition` and the operator handling for it are untouched, so any future sidecar container still works.

## Not done here

`images/languageserver/`, `images/theia-no-ls/`, `images/java-17-no-ls/` and `images/rust-no-ls/` are left on disk. Deleting them belongs to the EduIDE restructuring rather than this change, which is deliberately confined to the build workflow.

Companion PR: EduIDE/EduIDE-deployment#112 removes the matching preload entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined automated container image builds by removing several unused image variants.
  - Continued building all remaining supported images through the shared workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->