### PR TITLE
Fix npm/npx in JavaScript IDE and curate JS/TS extensions

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -33,7 +33,7 @@ This repository includes example implementations demonstrating the extension pat
 | Language   | Image Directory | Demonstrates |
 |------------|-----------------|--------------|
 | Java 17    | `java-17/`      | JDK installation, Maven, Java language server |
-| JavaScript | `javascript/`   | Node.js runtime, npm, TypeScript support |
+| JavaScript | `javascript/`   | Node.js runtime, npm/npx, corepack, TypeScript CLI (tsc, tsx) |
 | C          | `c/`            | GCC toolchain, C/C++ extensions |
 
 These examples serve as templates for creating additional language-specific variants of the web-based Theia IDE.

--- a/images/README.md
+++ b/images/README.md
@@ -33,7 +33,7 @@ This repository includes example implementations demonstrating the extension pat
 | Language   | Image Directory | Demonstrates |
 |------------|-----------------|--------------|
 | Java 17    | `java-17/`      | JDK installation, Maven, Java language server |
-| JavaScript | `javascript/`   | Node.js runtime, npm/npx, corepack, TypeScript CLI (tsc, tsx) |
+| JavaScript | `javascript/`   | Node.js runtime, npm/npx, corepack, TypeScript CLI (tsc, tsx), ESLint, Prettier |
 | C          | `c/`            | GCC toolchain, C/C++ extensions |
 
 These examples serve as templates for creating additional language-specific variants of the web-based Theia IDE.

--- a/images/javascript/ToolDockerfile
+++ b/images/javascript/ToolDockerfile
@@ -54,6 +54,11 @@ RUN n=0; until yarn add -W @theia/cli@1.70.0 --network-timeout 1000000 --network
         sleep $((n*3)); \
     done
 
+# Global TypeScript CLI tooling for the terminal: tsc (compile/type-check) and tsx
+# (run .ts files directly). tsx is self-contained and works with modern Node; ts-node
+# 10.x silently no-ops on Node 22.
+RUN npm install -g typescript@5.6.3 tsx@4.19.2
+
 # Download language-specific plugins
 RUN --mount=type=cache,id=theia-plugin-cache-javascript,target=/home/theia/.plugin-cache,sharing=locked \
     yarn download:plugins:smart
@@ -61,8 +66,10 @@ RUN --mount=type=cache,id=theia-plugin-cache-javascript,target=/home/theia/.plug
 # Final stage: Assemble the application
 FROM apt-deps AS final-ide
 
-# Copy Node.js from plugin-image (required for Theia runtime)
-COPY --from=plugin-image /usr/local/bin/node /usr/local/bin/
+# Copy Node.js from plugin-image (required for Theia runtime).
+# Copy the whole bin dir (not just the `node` binary): it carries the npm/npx/corepack
+# launcher symlinks plus the tsc/tsx launchers created by the global install above.
+COPY --from=plugin-image /usr/local/bin/ /usr/local/bin/
 COPY --from=plugin-image /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Switch to Theia user
@@ -88,6 +95,9 @@ ENV SHELL=/bin/zsh \
 
 # Use installed git instead of dugite
 ENV USE_LOCAL_GIT=true
+
+# Let plain `node`/`tsc` resolve the globally-installed npm packages (typescript, tsx)
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 WORKDIR /home/theia/applications/browser
 

--- a/images/javascript/package.json.patch
+++ b/images/javascript/package.json.patch
@@ -1,7 +1,12 @@
 {
   "theiaPlugins": {
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.88.1/file/eclipse-theia.builtin-extension-pack-1.88.1.vsix",
-    "js-essentials": "https://open-vsx.org/api/Gydunhn/javascript-essentials/0.1.1/file/Gydunhn.javascript-essentials-0.1.1.vsix"
+    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/3.0.34/file/dbaeumer.vscode-eslint-3.0.34.vsix",
+    "esbenp.prettier-vscode": "https://open-vsx.org/api/esbenp/prettier-vscode/12.4.0/file/esbenp.prettier-vscode-12.4.0.vsix",
+    "christian-kohler.path-intellisense": "https://open-vsx.org/api/christian-kohler/path-intellisense/2.8.0/file/christian-kohler.path-intellisense-2.8.0.vsix",
+    "christian-kohler.npm-intellisense": "https://open-vsx.org/api/christian-kohler/npm-intellisense/1.4.5/file/christian-kohler.npm-intellisense-1.4.5.vsix",
+    "formulahendry.auto-rename-tag": "https://open-vsx.org/api/formulahendry/auto-rename-tag/0.1.10/file/formulahendry.auto-rename-tag-0.1.10.vsix",
+    "EditorConfig.EditorConfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.18.2/file/EditorConfig.EditorConfig-0.18.2.vsix"
   },
   "theiaPluginsExcludeIdsRemove": [
     "ms-vscode.js-debug",

--- a/images/javascript/project/.vscode/settings.json
+++ b/images/javascript/project/.vscode/settings.json
@@ -10,8 +10,30 @@
      * JavaScript Essentials Config
      */
      "[javascript]": {
-        "editor.defaultFormatter": "vscode.typescript-language-features"
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "prettier.singleQuote": true,
+    "prettier.semi": true,
+    "editor.codeActionsOnSave": {
+        "source.addMissingImports": "always"
+    },
+    "javascript.updateImportsOnFileMove.enabled": "always",
+    "typescript.updateImportsOnFileMove.enabled": "always",
     "javascript.format.enable": true,
     "javascript.format.semicolons": "insert",
     "javascript.preferences.quoteStyle": "single",


### PR DESCRIPTION
## Summary

The JavaScript/TypeScript IDE variant advertised npm support but shipped none, and the developer extensions its settings referenced were never actually installed. This PR fixes both, in two commits.

### 1. Restore npm/npx + add TypeScript CLI (`fix(javascript)`)
The variant's final stage rebuilt Node by copying only the `node` binary and `/usr/local/lib/node_modules`, but not the `/usr/local/bin` launcher symlinks the official node image ships. npm's files were on disk, yet `npm`/`npx`/`corepack` were missing from `PATH`.

- Copy the whole `/usr/local/bin/` so the npm/npx/corepack launchers come along.
- Globally install `typescript` (`tsc`) and `tsx` so students can type-check and run `.ts` from the terminal. `tsx` is used instead of `ts-node`, which silently no-ops on Node 22.
- Set `NODE_PATH` so plain `node`/`tsc` resolve the global packages.

### 2. Bundle real JS/TS extensions + seamless auto-import (`feat(javascript)`)
The image relied on the `Gydunhn.javascript-essentials` extension **pack**, but Theia's `download:plugins` does not resolve a pack's member extensions, so ESLint/Prettier/IntelliSense the `settings.json` referenced were never installed. Now each extension is listed explicitly by VSIX URL (matching every other variant):

- ESLint (`dbaeumer.vscode-eslint`), Prettier (`esbenp.prettier-vscode`)
- Path IntelliSense, npm IntelliSense, Auto Rename Tag, EditorConfig

Prettier becomes the default formatter for JS/TS/JSON (aligned to the existing single-quote/semicolon style), and **auto-import** is enabled on save (`source.addMissingImports`) plus `updateImportsOnFileMove` - backed by the built-in TypeScript language service.

## Verification
Built `images/javascript/ToolDockerfile` against the GHCR base and confirmed in-container:

- `node`, `npm`, `npx`, `corepack`, `tsc`, `tsx` all resolve and print versions.
- Smoke test as the `theia` user: `npm init` works, `tsc a.ts` compiles, `node a.js` and `tsx a.ts` both run.
- All six extensions present under `/home/theia/plugins`; Prettier/auto-import settings shipped to `/home/project/.vscode/settings.json`.

## Notes
- `images/java-17/ToolDockerfile` has the same latent npm-symlink gap; left unchanged since Java rarely needs npm.
- `vscode.html`/`vscode.css`/npm-scripts explorer remain excluded to keep the image lean; easy to opt in later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)