### PR TITLE
chore: enforce vX.Y.Z release tags

### DIFF
--- a/.github/workflows/tag-format.yml
+++ b/.github/workflows/tag-format.yml
@@ -1,0 +1,19 @@
+# Enforce one spelling for release tags. The grammar lives in
+# EduIDE/.github so the repos cannot drift apart on it.
+#
+#   git tag       vX.Y.Z
+#   image tag      X.Y.Z
+#   chart version  X.Y.Z
+
+name: Tag format
+
+on:
+  push:
+    tags: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    uses: EduIDE/.github/.github/workflows/check-tag-format.yml@main


### PR DESCRIPTION
Calls the shared tag-format check from EduIDE/.github, so a tag push that is
not `vX.Y.Z` fails instead of quietly joining the three spellings this org
already has (`1.1.0`, `v1.1.0`, `v.1.1.1`).

The grammar lives in one place rather than being copied into each repo. Runs
only on tag pushes, so it costs nothing on a normal PR.

Depends on EduIDE/.github#3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for tag naming whenever a new tag is pushed.
  * Runs with read-only repository access to help ensure safe checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->