### PR TITLE
chore(renovate): onboard to the org-wide Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>EduIDE/.github:renovate-config"],
+  "dockerfile": {
+    "description": "16 of the 18 Dockerfiles here are named ToolDockerfile or BaseDockerfile. Renovate's default patterns only match a basename that starts with Dockerfile or has it after a dot, so without this it would see 2 of 18. managerFilePatterns merges with the defaults rather than replacing them.",
+    "managerFilePatterns": ["/(^|/)[^/]*[Dd]ockerfile$/"]
+  },
+  "docker-compose": {
+    "description": "Every image in the compose files is :local or :latest - nothing for Renovate to update.",
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "description": "Student course scaffolding baked into the -templates images, not real dependencies of this repo.",
+      "matchFileNames": ["images/*-templates/templates/**"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## What and why

Onboards this repo to the org-wide Renovate preset (`local>EduIDE/.github:renovate-config`, EduIDE/.github#4, not yet merged - Renovate will start working once it is).

**This is not the usual three-line `extends`, and the reason is the Dockerfile naming.**

16 of the 18 Dockerfiles in this repo are named `ToolDockerfile` or `BaseDockerfile`:

```
images/base-ide/BaseDockerfile
images/c/ToolDockerfile              images/java-25/ToolDockerfile
images/c-templates/ToolDockerfile    images/java-25-templates/ToolDockerfile
images/haskell/ToolDockerfile        images/javascript/ToolDockerfile
images/java-17/ToolDockerfile        images/ocaml/ToolDockerfile
images/java-17-no-ls/ToolDockerfile  images/python/ToolDockerfile
images/java-17-templates/ToolDockerfile  images/rust/ToolDockerfile
                                     images/rust-no-ls/ToolDockerfile
images/languageserver/java/Dockerfile    images/swift/ToolDockerfile
images/languageserver/rust/Dockerfile    images/theia-no-ls/ToolDockerfile
```

Renovate's default patterns for the `dockerfile` manager only match a basename that *starts* with `Dockerfile`, or has it after a dot (`foo.Dockerfile`). `ToolDockerfile` matches neither. Out of the box Renovate would have managed the two `images/languageserver/*/Dockerfile` files and silently ignored the other sixteen - including every `FROM ubuntu:24.04`, `FROM node:22-bullseye`, `FROM alpine:3.22` and `FROM eclipse-temurin:21-jdk-jammy` that the student images are actually built on. That is the bulk of this repo's attack surface, and it would have looked green.

`managerFilePatterns` merges with Renovate's defaults rather than replacing them, so adding one pattern fixes it without losing the standard names.

The other two overrides:

- **`docker-compose` disabled.** All five compose files (`docker-compose.images.yml` and the four `theia-ls-setup/docker-compose-*.yml`) reference only `:local` and `ghcr.io/eduide/eduide/*:latest`. There is no version anywhere for Renovate to move.
- **`images/*-templates/templates/**` disabled.** These trees are student course scaffolding that gets `COPY`d into the `-templates` images (`com.example` / `my-project` skeletons with a JUnit dep, a `MODULE.bazel`, a Gradle wrapper). Renovate's maven, gradle, gradle-wrapper, bazel-module and bazelisk managers all pick them up as if they were this repo's own build files. Note this covers all three template dirs - `java-17-templates`, `java-25-templates` and `c-templates` - not just the Java 17 one. Real build files outside those trees, e.g. `images/java-17/gradle/remote-cache.gradle`, stay managed.

## How it was verified

- `renovate-config-validator --strict renovate.json` (renovate 44.46.7): passes. Sanity-checked the validator itself by adding a bogus key - it fails as expected, so the pass is real.
- **Actual extraction run**, `renovate --platform=local --dry-run=extract` against this checkout, with the `extends` temporarily removed (the preset does not exist on `.github`'s default branch yet):
  - **without** the `dockerfile` override: `dockerfile: fileCount 2, depCount 3`
  - **with** it: `dockerfile: fileCount 18, depCount 68`, and all 18 files listed by name.
  - `docker-compose` disappears from the extraction with the override in place.
- Dockerfile inventory: `find images -name '*ockerfile*'` - 18 files, listed above.
- Compose image refs: `grep -n 'image:'` across all five files - 13 `:local`, 4 `ghcr.io/eduide/eduide/*:latest`. Nothing pinned.
- Template scaffolding: read `images/java-17-templates/templates/maven/pom.xml` (groupId `com.example`, artifactId `my-project`, one JUnit test dep) and `templates/gradle/build.gradle`. Confirmed `ToolDockerfile` line 93 does `COPY images/java-17-templates/templates /home/theia/templates`.
- The `matchFileNames` glob was checked against real paths with minimatch: it hits all three `*-templates/templates/` trees and does not hit `images/java-17/gradle/remote-cache.gradle` or the `ToolDockerfile`s.

## Deployment impact

- [ ] Changes a Helm chart (chart `version` bumped)
- [ ] Changes a published image
- [ ] Requires a config change in EduIDE-deployment
- [ ] Requires a cluster-level change (CRDs, Gateway, ClusterRoles)
- [x] None of the above

One new file. No build, image or workflow behaviour changes.

## Risk and rollback

Low. `renovate.json` does nothing until EduIDE/.github#4 merges and the Renovate app is enabled here. Worst case is noisy PRs; rollback is deleting the file or flipping `"enabled": false`.

The blast radius is the 18 Dockerfiles this unlocks. The preset batches minor/patch base-image bumps into one "container base images" PR, holds majors behind a Dependency Dashboard tick, quarantines releases for 5 days, and never automerges - so nothing lands without review, and `build.yml` builds every image on the PR.

---

## Two things the team should know

**1. No lint gate in this PR, and it is not an oversight.**

I intended to add `.github/workflows/ci.yml` running `yarn lint` on `pull_request` - the repo has a `lint` script that no workflow runs. I wrote it, then ran it locally against a clean checkout of `main`. **`yarn lint` is already red on `main`**, so I removed the workflow rather than open a PR with a permanently failing gate.

`yarn install --frozen-lockfile` works fine (~97s). `yarn lint` fails at the first step:

```
scripts/merge-package-json.js
  32:56  error  Use undefined instead of null  no-null/no-null
  49:32  error  Use undefined instead of null  no-null/no-null
  64:22  error  Use undefined instead of null  no-null/no-null
  77:28  error  Use undefined instead of null  no-null/no-null
```

Because `lint` is `eslint scripts && lerna run lint`, that `&&` means the workspace packages never get linted. Running eslint on them directly:

- `theia-extensions/launcher` - clean
- `theia-extensions/updater` - clean (1 deprecation warning)
- `theia-extensions/product` - **28 errors**: single-quote violations and missing semicolons in `theia-ide-about-dialog.tsx` and `theia-ide-getting-started-widget.tsx`, misaligned jsdoc asterisks, and 4 files under `src/browser/toolbar/` missing the required license header. 18 of the 28 are `--fix`able.
- `applications/electron` - eslint finds no enabled rules for its `scripts/` and `test/` JS files, so it lints nothing.

So it is 32 errors across two areas, most of them mechanical. Fixing them is a separate PR - the instruction for this one was explicitly not to go fixing lint across the monorepo, and I agree: a formatting sweep does not belong in a Renovate config change. Once that lands, the lint gate is a five-line workflow.

I could not run `lerna run lint` end to end locally - lerna 6's bundled yargs crashes on Node 26 (`ReferenceError: require is not defined in ES module scope`), and this machine only has Node 26 despite what the Homebrew `node@22` symlink claims. That is a local environment artifact, not a repo problem; CI on Node 22 would be fine. The per-package eslint runs above are what I actually verified.

`yarn test` is deliberately not proposed either, now or later. The only test in the repo is `applications/electron/test/app.spec.js`, a webdriverio smoke test that drives a fully packaged multi-gigabyte Electron binary. It is not viable in PR CI.

**2. Renovate will not touch the reusable-workflow pin in `build.yml`, and today that is fine.**

`build.yml` pins `EduIDE/.github/.github/workflows/build-and-push-docker-image.yml@v1`. That is a tag, so the `github-actions` manager *will* manage it and roll it to `v2` when one exists - correct behaviour, nothing to do.

Worth flagging because the brief for this PR said it was pinned to `@feature/split-build-workflow-modes`, an unmerged branch. That is no longer true on `main` - it was moved to `@v1`. If any other repo still points at a branch ref, Renovate will leave it alone permanently, because a branch has no version ordering to compare against. Not a misconfiguration, but it means such a pin is invisible to dependency management and has to be moved by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update configuration.
  * Improved detection of Dockerfiles with varied naming conventions.
  * Disabled unnecessary updates for local or latest-only Compose images.
  * Excluded student course scaffolding templates from automated update processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->