### PR TITLE
chore(ci): add dependency review to PR CI

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Renovate tells us about vulnerabilities we already have. This catches the
+# ones a PR is about to add: it diffs the PR's dependencies against main and
+# fails on a newly introduced advisory of high severity or above. Pre-existing
+# advisories are not this check's business.
+#
+# It lives in its own file rather than in build.yml because build.yml is the
+# image build train - it also runs on push, schedule and release, and a
+# dependency diff only exists on a pull request.
+#
+# The grammar lives in EduIDE/.github so the repos cannot drift apart on it.
+
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    uses: EduIDE/.github/.github/workflows/dependency-review.yml@v1


### PR DESCRIPTION
## What and why

Adds the org-wide `dependency-review` check to this repo's PR CI, in a new `.github/workflows/dependency-review.yml`.

Renovate already tells us about advisories on dependencies we *have*. This covers the other direction: it diffs a PR's dependencies against `main` and fails the PR if it *introduces* a dependency with a known advisory at high severity or above. Pre-existing advisories are out of scope for this check - which matters in a tree this size, where a lockfile carries a couple of thousand packages.

It gets its own file, next to `docs-check.yml` and `tag-format.yml`, rather than a job in `build.yml`. `build.yml` is the image build train: it also runs on push, schedule and release, and a dependency diff only exists on a pull request.

## How it was verified

- `actionlint` v1.7.6 on the repo: no findings in the new file. The findings it reports are pre-existing, in `scorpio_auto_update.yml` (old action versions, SC2116/SC2086), and untouched here.
- Checked that GitHub's dependency graph has data for this repo (`GET /repos/EduIDE/EduIDE/dependency-graph/sbom`): 2074 npm packages across the yarn workspaces, so the action has something to compare.
- Confirmed the repo is public. The advisory API behind this action needs GitHub Advanced Security on private repos; this one is public, so it works on the free tier.
- The check's own run on this PR is the real test. Its result is visible in the checks list below.

What I did not verify: that the check behaves sensibly on a PR that actually bumps a dependency. This PR touches no manifest, so the diff it reviews is empty. The first Renovate PR after this merges will be the first real exercise.

## Deployment impact

- [ ] Changes a Helm chart (chart `version` bumped)
- [ ] Changes a published image
- [ ] Requires a config change in EduIDE-deployment
- [ ] Requires a cluster-level change (CRDs, Gateway, ClusterRoles)
- [x] None of the above

CI only. The image build train is untouched.

## Risk and rollback

Low. Worst case is a false positive blocking a PR, which is not silent - the job log names the offending package and advisory. It is not a required check unless someone makes it one, so it can be overridden by merging anyway.

Rollback: revert this commit, or delete `.github/workflows/dependency-review.yml`.
