### PR TITLE
Reduce Java IDE image memory footprint by 65% (java-17 + java-25)

### DIFF
--- a/docs/how-to-build-ide-variants.md
+++ b/docs/how-to-build-ide-variants.md
@@ -282,6 +282,10 @@ Once added, your variant will be built automatically on:
 - Releases
 - Manual workflow dispatch
 
+## Memory tuning
+
+The Java variants cap all resident JVM and node processes so many environments fit on one host. See [java-image-memory-tuning.md](java-image-memory-tuning.md) before changing Gradle or language server settings in those images.
+
 ## Tips
 
 - **Keep it minimal**: Only include tools and extensions actually needed for the language

--- a/docs/java-image-memory-tuning.md
+++ b/docs/java-image-memory-tuning.md
@@ -1,0 +1,66 @@
+# Java image memory tuning
+
+The `java-17` and `java-17-templates` images cap every resident JVM and node process so that many student environments can run per host. Without this tuning, a hello-world environment settles above 2GB: two JDT language server JVMs (redhat.java 1.56 defaults to `-Xmx2G`), up to three Gradle daemons (512MB each, 3h idle timeout, unable to share because they run on different JVMs), and uncapped node processes.
+
+## Where each knob lives
+
+| Knob | File | Applied to |
+|---|---|---|
+| `org.gradle.jvmargs`, `org.gradle.java.home`, daemon idle timeout, workers | `images/java-17/gradle/gradle.properties` -> baked to `~/.gradle/gradle.properties` | Both Gradle daemons (IDE import + terminal) |
+| Test JVM heap cap (Gradle) | `images/java-17/gradle/test-memory.gradle` -> baked to `~/.gradle/init.d/` | Any Gradle project, incl. mounted course repos |
+| `java.jdt.ls.vmargs`, `java.server.launchMode` | `images/java-17/theia/user-settings.json` -> baked to `/home/theia/.theia-ide/settings.json` | JDT language server |
+| `MAVEN_OPTS`, `NODE_OPTIONS`, `MALLOC_ARENA_MAX` | `ENV` block in both `ToolDockerfile`s | Maven, Theia node processes, all glibc processes |
+| Surefire test JVM heap cap | `templates/maven/pom.xml` (`argLine`) | Maven test forks (Surefire does not inherit `MAVEN_OPTS`) |
+| Debuggee heap cap | `templates/*/.vscode/launch.json` (`vmArgs`) | The student's app under debug |
+
+Both `ToolDockerfile`s copy the shared files from `images/java-17/`, same pattern as `remote-cache.gradle`.
+
+## The one-daemon invariant
+
+The IDE's Java extension imports Gradle projects through the Gradle Tooling API, which starts its own daemon. A terminal `./gradlew` starts another. Gradle only reuses a daemon when Gradle version, java home, and daemon JVM args all match.
+
+Two things make the daemons identical so they share:
+
+1. `java.import.gradle.jvmArguments` is unset, so the import daemon reads `org.gradle.jvmargs` from `~/.gradle/gradle.properties`, exactly like the terminal daemon.
+2. `org.gradle.java.home=/home/theia/jdk` pins both daemons to the same JVM (the symlink is created in the `ToolDockerfile` and points to the container JDK). Without this pin, the import daemon runs on redhat.java's **embedded JRE 21** while the terminal daemon runs on the system JDK 17, and they can never share; measurements showed three daemons piling up that way.
+
+**Never set `java.import.gradle.jvmArguments` in IDE settings. Change `org.gradle.jvmargs` in `images/java-17/gradle/gradle.properties` instead.** Setting it splits the import back into a second daemon (~350MB) and triggers a security prompt in the Java extension.
+
+Edge case: if `./gradlew` runs while the import daemon is busy, Gradle briefly starts a second daemon; the 2-minute idle timeout reaps the spare.
+
+## Why G1 with periodic GC for the language server
+
+The JDT LS vmargs use `-XX:+UseG1GC -XX:G1PeriodicGCInterval=30000 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=25`. The periodic GC (JEP 346) runs a concurrent cycle after 30s idle and returns unused heap pages to the OS, so the process shrinks back after the import spike. SerialGC was deliberately not used here: it only collects when the old generation fills, so a long-lived idle language server would stay pinned at its peak RSS forever. The short-lived Gradle daemon does use SerialGC (smallest footprint); its idle timeout reclaims the memory instead.
+
+## Raising limits for bigger course projects
+
+The defaults target hello-world up to medium single-module projects. For multi-module or framework-heavy courses (e.g. Spring), build a course variant that overrides:
+
+- `-Xmx768m` in `java.jdt.ls.vmargs` (`user-settings.json`); do not go below 512m, JDT LS OOMs on larger projects around 350-450m
+- `-Xmx256m` in `org.gradle.jvmargs` (`gradle.properties`); raise to 512m for heavy builds
+- `maxHeapSize` in `test-memory.gradle` / `argLine` in the pom if tests need more
+
+## Consciously skipped options
+
+- `org.gradle.daemon=false`: only affects CLI runs, the Tooling API always uses a daemon; it would reintroduce the two-JVM split and add 10-15s to every run. The 2-minute idle timeout is the middle ground.
+- `org.gradle.configuration-cache`: marginal RAM benefit, compatibility risk with the Tooling API on Gradle 9.
+- `java.server.launchMode: LightWeight`: no classpath-aware completion, no run/debug/test. `Standard` is used instead of the default `Hybrid`, which removes the second (syntax-server) JVM.
+- `images/languageserver/java` sidecar (only used by the no-ls variants): out of scope, unchanged.
+
+## Notes
+
+- `NODE_OPTIONS=--max-old-space-size=512` is inherited by any node a student starts in the terminal. Irrelevant for the Java images; keep in mind if this pattern is copied to a JavaScript image.
+- V8 crashes hard when it hits the cap. If plugin-host crashes appear in the field, raise the cap before debugging anything else.
+- `MALLOC_ARENA_MAX=2` limits glibc malloc arenas; without it, multi-threaded processes on many-core hosts waste 100-300MB of native RSS on arena fragmentation.
+
+## Measured results (hello-world gradle template, arm64, OrbStack, 2026-08)
+
+Same image, "before" = tuning files removed and env caps unset at runtime. Values are cgroup `memory.current`.
+
+| State | Before | After |
+|---|---|---|
+| IDE open, Java LS ready, project imported | 2107 MB | 859 MB |
+| Right after `./gradlew build` in the terminal | 2514 MB | 1248 MB |
+| 3 min idle after the build | 2504 MB | 874 MB |
+
+Process-level, at 3 min idle: before keeps one JDT LS (800 MB) plus **three** Gradle daemons (486+448+433 MB) resident for 3 hours; after keeps one JDT LS (576 MB) and zero daemons. Warm terminal builds take ~0.6s, cold (daemon restart) ~7s.

--- a/docs/java-image-memory-tuning.md
+++ b/docs/java-image-memory-tuning.md
@@ -1,19 +1,19 @@
 # Java image memory tuning
 
-The `java-17` and `java-17-templates` images cap every resident JVM and node process so that many student environments can run per host. Without this tuning, a hello-world environment settles above 2GB: two JDT language server JVMs (redhat.java 1.56 defaults to `-Xmx2G`), up to three Gradle daemons (512MB each, 3h idle timeout, unable to share because they run on different JVMs), and uncapped node processes.
+The Java images (`java-17`, `java-17-templates`, `java-25`, `java-25-templates`) cap every resident JVM and node process so that many student environments can run per host. Without this tuning, a hello-world environment settles above 2GB: two JDT language server JVMs (redhat.java 1.56 defaults to `-Xmx2G`), up to three Gradle daemons (512MB each, 3h idle timeout, unable to share because they run on different JVMs), and uncapped node processes.
 
 ## Where each knob lives
 
 | Knob | File | Applied to |
 |---|---|---|
-| `org.gradle.jvmargs`, `org.gradle.java.home`, daemon idle timeout, workers | `images/java-17/gradle/gradle.properties` -> baked to `~/.gradle/gradle.properties` | Both Gradle daemons (IDE import + terminal) |
-| Test JVM heap cap (Gradle) | `images/java-17/gradle/test-memory.gradle` -> baked to `~/.gradle/init.d/` | Any Gradle project, incl. mounted course repos |
-| `java.jdt.ls.vmargs`, `java.server.launchMode` | `images/java-17/theia/user-settings.json` -> baked to `/home/theia/.theia-ide/settings.json` | JDT language server |
+| `org.gradle.jvmargs`, `org.gradle.java.home`, daemon idle timeout, workers | `images/java-{17,25}/gradle/gradle.properties` -> baked to `~/.gradle/gradle.properties` | Both Gradle daemons (IDE import + terminal) |
+| Test JVM heap cap (Gradle) | `images/java-{17,25}/gradle/test-memory.gradle` -> baked to `~/.gradle/init.d/` | Any Gradle project, incl. mounted course repos |
+| `java.jdt.ls.vmargs`, `java.server.launchMode` | `images/java-{17,25}/theia/user-settings.json` -> baked to `/home/theia/.theia-ide/settings.json` | JDT language server |
 | `MAVEN_OPTS`, `NODE_OPTIONS`, `MALLOC_ARENA_MAX` | `ENV` block in both `ToolDockerfile`s | Maven, Theia node processes, all glibc processes |
 | Surefire test JVM heap cap | `templates/maven/pom.xml` (`argLine`) | Maven test forks (Surefire does not inherit `MAVEN_OPTS`) |
 | Debuggee heap cap | `templates/*/.vscode/launch.json` (`vmArgs`) | The student's app under debug |
 
-Both `ToolDockerfile`s copy the shared files from `images/java-17/`, same pattern as `remote-cache.gradle`.
+Each Java version directory carries its own copy of the three tuning files (same pattern as `remote-cache.gradle`); the `*-templates` Dockerfiles reuse their version's copies. Keep the copies in sync unless a version deliberately diverges.
 
 ## The one-daemon invariant
 

--- a/images/java-17-templates/ToolDockerfile
+++ b/images/java-17-templates/ToolDockerfile
@@ -80,9 +80,20 @@ WORKDIR /home/theia
 # Copy application from the base image (includes prod node_modules)
 COPY --from=base-ide --chown=theia:theia /home/theia /home/theia
 
-# Gradle Remote Cache Setup
-RUN mkdir -p /home/theia/.gradle/init.d
+# Gradle Remote Cache Setup + memory tuning
+# The /home/theia/jdk symlink gives gradle.properties an arch-independent
+# org.gradle.java.home so IDE-import and terminal builds share one daemon.
+RUN ln -s "${JAVA_HOME}" /home/theia/jdk && \
+    mkdir -p /home/theia/.gradle/init.d
 COPY --chown=theia:theia images/java-17/gradle/remote-cache.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-17/gradle/test-memory.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-17/gradle/gradle.properties /home/theia/.gradle/gradle.properties
+
+# Bake user-level (machine-scoped) Java LS memory settings. Must be user-level:
+# java.jdt.ls.vmargs is security-gated in workspace settings and /home/project
+# may be replaced by a mounted student volume.
+RUN mkdir -p /home/theia/.theia-ide
+COPY --chown=theia:theia images/java-17/theia/user-settings.json /home/theia/.theia-ide/settings.json
 
 # Copy additional plugins
 COPY --from=plugin-image --chown=theia:theia /home/theia/plugins /home/theia/plugins
@@ -106,6 +117,11 @@ ENV SHELL=/bin/zsh \
 
 # Use installed git instead of dugite
 ENV USE_LOCAL_GIT=true
+
+# Cap JVM/node heaps and glibc arena count for constrained student environments
+ENV MAVEN_OPTS="-XX:+UseSerialGC -Xmx256m -XX:MaxMetaspaceSize=192m" \
+    NODE_OPTIONS="--max-old-space-size=512" \
+    MALLOC_ARENA_MAX=2
 
 WORKDIR /home/theia/applications/browser
 

--- a/images/java-17-templates/templates/gradle/.vscode/launch.json
+++ b/images/java-17-templates/templates/gradle/.vscode/launch.json
@@ -6,6 +6,7 @@
             "name": "Debug App",
             "request": "launch",
             "mainClass": "com.example.App",
+            "vmArgs": "-Xmx256m"
         }
     ]
 }

--- a/images/java-17-templates/templates/maven/.vscode/launch.json
+++ b/images/java-17-templates/templates/maven/.vscode/launch.json
@@ -6,7 +6,8 @@
             "name": "Debug App",
             "request": "launch",
             "mainClass": "com.example.App",
-            "projectName": "my-project"
+            "projectName": "my-project",
+            "vmArgs": "-Xmx256m"
         }
     ]
 }

--- a/images/java-17-templates/templates/maven/pom.xml
+++ b/images/java-17-templates/templates/maven/pom.xml
@@ -31,6 +31,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.2</version>
+                <configuration>
+                    <!-- Surefire forks its own JVM; MAVEN_OPTS does not apply to it -->
+                    <argLine>-Xmx256m</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/images/java-17/ToolDockerfile
+++ b/images/java-17/ToolDockerfile
@@ -77,9 +77,20 @@ WORKDIR /home/theia
 # Copy application from the base image (includes prod node_modules)
 COPY --from=base-ide --chown=theia:theia /home/theia /home/theia
 
-# Gradle Remote Cache Setup
-RUN mkdir -p /home/theia/.gradle/init.d
+# Gradle Remote Cache Setup + memory tuning
+# The /home/theia/jdk symlink gives gradle.properties an arch-independent
+# org.gradle.java.home so IDE-import and terminal builds share one daemon.
+RUN ln -s "${JAVA_HOME}" /home/theia/jdk && \
+    mkdir -p /home/theia/.gradle/init.d
 COPY --chown=theia:theia images/java-17/gradle/remote-cache.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-17/gradle/test-memory.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-17/gradle/gradle.properties /home/theia/.gradle/gradle.properties
+
+# Bake user-level (machine-scoped) Java LS memory settings. Must be user-level:
+# java.jdt.ls.vmargs is security-gated in workspace settings and /home/project
+# may be replaced by a mounted student volume.
+RUN mkdir -p /home/theia/.theia-ide
+COPY --chown=theia:theia images/java-17/theia/user-settings.json /home/theia/.theia-ide/settings.json
 
 # Copy additional plugins
 COPY --from=plugin-image --chown=theia:theia /home/theia/plugins /home/theia/plugins
@@ -95,6 +106,11 @@ ENV SHELL=/bin/zsh \
 
 # Use installed git instead of dugite
 ENV USE_LOCAL_GIT=true
+
+# Cap JVM/node heaps and glibc arena count for constrained student environments
+ENV MAVEN_OPTS="-XX:+UseSerialGC -Xmx256m -XX:MaxMetaspaceSize=192m" \
+    NODE_OPTIONS="--max-old-space-size=512" \
+    MALLOC_ARENA_MAX=2
 
 WORKDIR /home/theia/applications/browser
 

--- a/images/java-17/gradle/gradle.properties
+++ b/images/java-17/gradle/gradle.properties
@@ -1,0 +1,24 @@
+# Memory tuning for student environments.
+# These apply to BOTH the daemon spawned by the Java language server's
+# project import (Gradle Tooling API) and the daemon spawned by
+# ./gradlew in the terminal. Identical JVM args + same wrapper
+# distribution means Gradle reuses ONE daemon for both.
+# IMPORTANT: never set java.import.gradle.jvmArguments in the IDE settings,
+# it would split the import back into its own daemon. Change org.gradle.jvmargs here instead.
+org.gradle.jvmargs=-Xmx256m -Xms64m -XX:MaxMetaspaceSize=256m -XX:+UseSerialGC
+
+# Pin the daemon JVM to a stable path (symlink to the container JDK, see ToolDockerfile).
+# Without this, the language server import daemon runs on redhat.java's embedded JRE
+# while the terminal daemon runs on the system JDK - two daemons that can never share.
+org.gradle.java.home=/home/theia/jdk
+
+# Stop the daemon after 2 minutes idle instead of the default 3 hours.
+# Keeps edit-run loops fast (warm daemon) but reclaims ~300-400MB when idle.
+org.gradle.daemon.idletimeout=120000
+
+# Single-module student projects gain nothing from parallelism.
+org.gradle.parallel=false
+org.gradle.workers.max=1
+
+# File-system watching keeps extra state resident; cheap to disable for tiny projects.
+org.gradle.vfs.watch=false

--- a/images/java-17/gradle/test-memory.gradle
+++ b/images/java-17/gradle/test-memory.gradle
@@ -1,0 +1,7 @@
+// Cap forked test JVMs (Gradle default allows 512m per fork).
+// Lives in ~/.gradle/init.d so it covers the template and any mounted course repo.
+allprojects {
+    tasks.withType(Test).configureEach {
+        maxHeapSize = '256m'
+    }
+}

--- a/images/java-17/theia/user-settings.json
+++ b/images/java-17/theia/user-settings.json
@@ -1,0 +1,16 @@
+{
+    "java.server.launchMode": "Standard",
+    "java.jdt.ls.vmargs": "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1PeriodicGCInterval=30000 -Xmx768m -Xms64m -Xss512k -XX:MaxMetaspaceSize=256m -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=25",
+    "java.completion.maxResults": 30,
+    "java.help.collectErrorLog": false,
+    "java.help.firstView": "none",
+    "java.help.showReleaseNotes": false,
+    "java.silentNotification": true,
+    "redhat.telemetry.enabled": false,
+    "files.watcherExclude": {
+        "**/.gradle/**": true,
+        "**/build/**": true,
+        "**/target/**": true,
+        "**/.git/objects/**": true
+    }
+}

--- a/images/java-25-templates/ToolDockerfile
+++ b/images/java-25-templates/ToolDockerfile
@@ -101,9 +101,20 @@ WORKDIR /home/theia
 # Copy application from the base image (includes prod node_modules)
 COPY --from=base-ide --chown=theia:theia /home/theia /home/theia
 
-# Gradle Remote Cache Setup
-RUN mkdir -p /home/theia/.gradle/init.d
+# Gradle Remote Cache Setup + memory tuning
+# The /home/theia/jdk symlink gives gradle.properties an arch-independent
+# org.gradle.java.home so IDE-import and terminal builds share one daemon.
+RUN ln -s "${JAVA_HOME}" /home/theia/jdk && \
+    mkdir -p /home/theia/.gradle/init.d
 COPY --chown=theia:theia images/java-25/gradle/remote-cache.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-25/gradle/test-memory.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-25/gradle/gradle.properties /home/theia/.gradle/gradle.properties
+
+# Bake user-level (machine-scoped) Java LS memory settings. Must be user-level:
+# java.jdt.ls.vmargs is security-gated in workspace settings and /home/project
+# may be replaced by a mounted student volume.
+RUN mkdir -p /home/theia/.theia-ide
+COPY --chown=theia:theia images/java-25/theia/user-settings.json /home/theia/.theia-ide/settings.json
 
 # Copy additional plugins
 COPY --from=plugin-image --chown=theia:theia /home/theia/plugins /home/theia/plugins
@@ -127,6 +138,11 @@ ENV SHELL=/bin/zsh \
 
 # Use installed git instead of dugite
 ENV USE_LOCAL_GIT=true
+
+# Cap JVM/node heaps and glibc arena count for constrained student environments
+ENV MAVEN_OPTS="-XX:+UseSerialGC -Xmx256m -XX:MaxMetaspaceSize=192m" \
+    NODE_OPTIONS="--max-old-space-size=512" \
+    MALLOC_ARENA_MAX=2
 
 WORKDIR /home/theia/applications/browser
 

--- a/images/java-25-templates/templates/gradle/.vscode/launch.json
+++ b/images/java-25-templates/templates/gradle/.vscode/launch.json
@@ -6,6 +6,7 @@
             "name": "Debug App",
             "request": "launch",
             "mainClass": "com.example.App",
+            "vmArgs": "-Xmx256m"
         }
     ]
 }

--- a/images/java-25-templates/templates/maven/.vscode/launch.json
+++ b/images/java-25-templates/templates/maven/.vscode/launch.json
@@ -6,7 +6,8 @@
             "name": "Debug App",
             "request": "launch",
             "mainClass": "com.example.App",
-            "projectName": "my-project"
+            "projectName": "my-project",
+            "vmArgs": "-Xmx256m"
         }
     ]
 }

--- a/images/java-25-templates/templates/maven/pom.xml
+++ b/images/java-25-templates/templates/maven/pom.xml
@@ -30,6 +30,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
+                <configuration>
+                    <!-- Surefire forks its own JVM; MAVEN_OPTS does not apply to it -->
+                    <argLine>-Xmx256m</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/images/java-25/ToolDockerfile
+++ b/images/java-25/ToolDockerfile
@@ -102,9 +102,20 @@ WORKDIR /home/theia
 # Copy application from the base image (includes prod node_modules)
 COPY --from=base-ide --chown=theia:theia /home/theia /home/theia
 
-# Gradle Remote Cache Setup
-RUN mkdir -p /home/theia/.gradle/init.d
+# Gradle Remote Cache Setup + memory tuning
+# The /home/theia/jdk symlink gives gradle.properties an arch-independent
+# org.gradle.java.home so IDE-import and terminal builds share one daemon.
+RUN ln -s "${JAVA_HOME}" /home/theia/jdk && \
+    mkdir -p /home/theia/.gradle/init.d
 COPY --chown=theia:theia images/java-25/gradle/remote-cache.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-25/gradle/test-memory.gradle /home/theia/.gradle/init.d/
+COPY --chown=theia:theia images/java-25/gradle/gradle.properties /home/theia/.gradle/gradle.properties
+
+# Bake user-level (machine-scoped) Java LS memory settings. Must be user-level:
+# java.jdt.ls.vmargs is security-gated in workspace settings and /home/project
+# may be replaced by a mounted student volume.
+RUN mkdir -p /home/theia/.theia-ide
+COPY --chown=theia:theia images/java-25/theia/user-settings.json /home/theia/.theia-ide/settings.json
 
 # Copy additional plugins
 COPY --from=plugin-image --chown=theia:theia /home/theia/plugins /home/theia/plugins
@@ -120,6 +131,11 @@ ENV SHELL=/bin/zsh \
 
 # Use installed git instead of dugite
 ENV USE_LOCAL_GIT=true
+
+# Cap JVM/node heaps and glibc arena count for constrained student environments
+ENV MAVEN_OPTS="-XX:+UseSerialGC -Xmx256m -XX:MaxMetaspaceSize=192m" \
+    NODE_OPTIONS="--max-old-space-size=512" \
+    MALLOC_ARENA_MAX=2
 
 WORKDIR /home/theia/applications/browser
 

--- a/images/java-25/gradle/gradle.properties
+++ b/images/java-25/gradle/gradle.properties
@@ -1,0 +1,24 @@
+# Memory tuning for student environments.
+# These apply to BOTH the daemon spawned by the Java language server's
+# project import (Gradle Tooling API) and the daemon spawned by
+# ./gradlew in the terminal. Identical JVM args + same wrapper
+# distribution means Gradle reuses ONE daemon for both.
+# IMPORTANT: never set java.import.gradle.jvmArguments in the IDE settings,
+# it would split the import back into its own daemon. Change org.gradle.jvmargs here instead.
+org.gradle.jvmargs=-Xmx256m -Xms64m -XX:MaxMetaspaceSize=256m -XX:+UseSerialGC
+
+# Pin the daemon JVM to a stable path (symlink to the container JDK, see ToolDockerfile).
+# Without this, the language server import daemon runs on redhat.java's embedded JRE
+# while the terminal daemon runs on the system JDK - two daemons that can never share.
+org.gradle.java.home=/home/theia/jdk
+
+# Stop the daemon after 2 minutes idle instead of the default 3 hours.
+# Keeps edit-run loops fast (warm daemon) but reclaims ~300-400MB when idle.
+org.gradle.daemon.idletimeout=120000
+
+# Single-module student projects gain nothing from parallelism.
+org.gradle.parallel=false
+org.gradle.workers.max=1
+
+# File-system watching keeps extra state resident; cheap to disable for tiny projects.
+org.gradle.vfs.watch=false

--- a/images/java-25/gradle/test-memory.gradle
+++ b/images/java-25/gradle/test-memory.gradle
@@ -1,0 +1,7 @@
+// Cap forked test JVMs (Gradle default allows 512m per fork).
+// Lives in ~/.gradle/init.d so it covers the template and any mounted course repo.
+allprojects {
+    tasks.withType(Test).configureEach {
+        maxHeapSize = '256m'
+    }
+}

--- a/images/java-25/theia/user-settings.json
+++ b/images/java-25/theia/user-settings.json
@@ -1,0 +1,16 @@
+{
+    "java.server.launchMode": "Standard",
+    "java.jdt.ls.vmargs": "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1PeriodicGCInterval=30000 -Xmx768m -Xms64m -Xss512k -XX:MaxMetaspaceSize=256m -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=25",
+    "java.completion.maxResults": 30,
+    "java.help.collectErrorLog": false,
+    "java.help.firstView": "none",
+    "java.help.showReleaseNotes": false,
+    "java.silentNotification": true,
+    "redhat.telemetry.enabled": false,
+    "files.watcherExclude": {
+        "**/.gradle/**": true,
+        "**/build/**": true,
+        "**/target/**": true,
+        "**/.git/objects/**": true
+    }
+}


### PR DESCRIPTION
## What is the change?

Runtime memory tuning for all Java IDE images (`java-17`, `java-17-templates`, `java-25`, `java-25-templates`). A hello-world Java environment previously settled at ~2.5GB resident; it now settles at ~870MB (65% reduction), verified by container memory measurements.

The `java-25` images landed on `main` (#169) as untuned copies of the `java-17` pattern; this PR applies the identical tuning there. Each version directory keeps its own copy of the three tuning files, following the existing `remote-cache.gradle` convention.

## Reason for the change

Without tuning, a hello-world environment accumulates:
- Up to **three resident Gradle daemons**: the IDE's Java extension imports Gradle projects through the Gradle Tooling API (its own daemon), and a terminal `./gradlew` starts another. They ran on different JVMs (redhat.java's embedded JRE 21 vs the system JDK 17), so Gradle could never reuse one, and each sat idle for the default 3-hour timeout at ~512MB.
- **Two JDT language server JVMs**: redhat.java 1.56 defaults `java.server.launchMode` to `Hybrid`, which starts a second syntax-only JVM alongside the main one, each defaulting to `-Xmx2G`.
- No heap caps anywhere else: Gradle test forks, Maven (including Surefire forks, which do not inherit `MAVEN_OPTS`), and node all ran uncapped.

This adds up fast when many student environments run per host.

## What changed

| Knob | File | Applied to |
|---|---|---|
| `org.gradle.jvmargs`, `org.gradle.java.home`, daemon idle timeout, workers | [`images/java-17/gradle/gradle.properties`](images/java-17/gradle/gradle.properties) -> baked to `~/.gradle/gradle.properties` | Both Gradle daemons (IDE import + terminal) |
| Test JVM heap cap (Gradle) | [`images/java-17/gradle/test-memory.gradle`](images/java-17/gradle/test-memory.gradle) -> baked to `~/.gradle/init.d/` | Any Gradle project, incl. mounted course repos |
| `java.jdt.ls.vmargs`, `java.server.launchMode` | [`images/java-17/theia/user-settings.json`](images/java-17/theia/user-settings.json) -> baked to `/home/theia/.theia-ide/settings.json` | JDT language server |
| `MAVEN_OPTS`, `NODE_OPTIONS`, `MALLOC_ARENA_MAX` | `ENV` block in all four `ToolDockerfile`s | Maven, Theia node processes, all glibc processes |
| Surefire test JVM heap cap | [`templates/maven/pom.xml`](images/java-17-templates/templates/maven/pom.xml) (`argLine`) | Maven test forks |
| Debuggee heap cap | `templates/{gradle,maven}/.vscode/launch.json` (`vmArgs`) | The student's app under debug |

The `user-settings.json` is baked at the **user** level rather than workspace level: `java.jdt.ls.vmargs` is machine-scoped and security-gated in workspace settings, and `/home/project` may be replaced by a mounted course/student volume anyway.

The `/home/theia/jdk` symlink (created in both `ToolDockerfile`s, pointing at `${JAVA_HOME}`) plus leaving `java.import.gradle.jvmArguments` unset is what makes the IDE-import daemon and the terminal `./gradlew` daemon identical, so Gradle collapses them into a single shared daemon instead of two (or three, under contention) piling up. Full rationale, the one-daemon invariant, why G1 with periodic GC is used for the language server instead of SerialGC, and guidance for raising the caps on heavier course projects are all written up in [`docs/java-image-memory-tuning.md`](docs/java-image-memory-tuning.md), linked from [`docs/how-to-build-ide-variants.md`](docs/how-to-build-ide-variants.md).

## How to Test

1. Build either image: `docker build -f images/java-17/ToolDockerfile .` or the `-templates` variant.
2. Start a container, open a hello-world Gradle or Maven project in the IDE, and let the Java extension finish importing.
3. Inspect the JDT LS process: only one JVM should be running, with the `-Xmx768m -XX:+UseG1GC -XX:G1PeriodicGCInterval=30000` args from `user-settings.json` (previously: two JVMs, each `-Xmx2G`).
4. Run `./gradlew build` in the terminal, then check `ps` / `jps` for Gradle daemons: exactly one, using `org.gradle.java.home=/home/theia/jdk` (previously: a second daemon on a different JVM).
5. Wait 2 minutes idle after the build; the Gradle daemon should be reaped (previously: idle for 3 hours).
6. Confirm `./gradlew test` and `mvn test` fork JVMs capped at `-Xmx256m` (Gradle test worker and Surefire fork respectively).
7. Confirm `mvn test` still passes in the maven template.

## Verified results

Measured via headless-browser-driven before/after on the same image (before = tuning files removed and env caps unset at runtime), cgroup `memory.current`:

| State | Before | After |
|---|---|---|
| IDE ready, project imported | 2107 MB | 859 MB |
| Right after terminal `./gradlew build` | 2514 MB | 1248 MB |
| 3 min idle after the build | 2504 MB | 874 MB |

Also confirmed: exactly one JDT LS JVM with the new vmargs (before: two at `-Xmx2G`); exactly one shared Gradle daemon on `/home/theia/jdk`, reaped after 2 min idle; Gradle test worker and Surefire fork both capped at `-Xmx256m`; warm `./gradlew build` ~0.6s; maven template `mvn test` passes.

Measurements were done on the `java-17-templates` image. The `java-25` edits are byte-identical apart from paths (`docker build --check` clean); CI builds both.

## Known tradeoffs

- Cold builds pay a ~7s daemon restart penalty after the 2-minute idle timeout reaps the Gradle daemon.
- Heavy course projects (multi-module builds, Spring, etc.) may need more than the 768m JDT LS cap or 256m Gradle cap. This should be handled with a course-specific image variant that overrides these values; see the "Raising limits" section in `docs/java-image-memory-tuning.md`.

## Screenshots

N/A (no UI changes).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CMk8vEG7qtCGZNWp5zttY
