### PR TITLE
fix: do not override the image tag on a release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,11 @@ jobs:
       docker-file: images/base-ide/BaseDockerfile
       image-name: eduide/eduide/base
       docker-context: .
-      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
+      # Deliberately NOT passed on a release. An override is used verbatim by
+      # the shared workflow, which would defeat its `${RELEASE_TAG#v}`
+      # normalisation and publish `v1.2.0` instead of `1.2.0` - a tag no chart
+      # can consume, since appVersion and the image tag must be one string.
+      image-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
     secrets: inherit
 
@@ -90,6 +94,7 @@ jobs:
       docker-context: .
       build-args: |
         BASE_IDE_TAG=${{ needs.base.outputs.sha_tag }}
-      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
+      # Deliberately NOT passed on a release. See the note on the base job.
+      image-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
     secrets: inherit


### PR DESCRIPTION
## Problem

`.github/workflows/build.yml` passed the raw git tag as an `image-tag` override on release builds:

```yaml
image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || ... }}
```

The shared workflow `EduIDE/.github/.github/workflows/build-and-push-docker-image.yml` normalises a release tag with `BASE_TAG=$(slug "${RELEASE_TAG#v}")`, but an explicit override short-circuits that branch and is used verbatim.

So tagging `v1.2.0` would have published `ghcr.io/eduide/eduide/<name>:v1.2.0` for the base image and all eleven language images. The convention is `git tag vX.Y.Z` -> image tag `X.Y.Z`, and the chart's `appVersion` has to be the same string as the image tag it resolves to, so nothing could have consumed those images.

## Change

Drop the override for the `release` event in both the `base` job and the `images` matrix job. The `workflow_dispatch` override stays, which is the case where an explicit tag is actually wanted.

Same fix as EduIDE-Cloud#134 and EduIDE-Landing-Page#42.

## Verification

- `actionlint .github/workflows/build.yml` passes.
- On a release the shared workflow now takes its `release` branch and derives `1.2.0` from tag `v1.2.0`.
- PR and `main` builds are unaffected: the override was already empty for those events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qeiQRFu8xAMRYWPdZewjG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release image tagging by relying on standardized tag normalization.
  * Preserved custom image tags for manually triggered workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->